### PR TITLE
Correct history file parsing.

### DIFF
--- a/timeline.c
+++ b/timeline.c
@@ -58,7 +58,7 @@ rewind_parseTimeLineHistory(char *buffer, TimeLineID targetTLI, int *nentries)
 		if (!(*bufptr))
 			lastline = true;
 		else
-			*bufptr = '\0';
+			*bufptr++ = '\0';
 
 		/* skip leading whitespace and check for # comment */
 		for (ptr = fline; *ptr; ptr++)


### PR DESCRIPTION
Fix a history file parsing error which prevent parsing the hole history file.

This commit should fix errors when reseting a old master with timeline id > 1
and new master with timeline id >2.

Formerly the error message "could not find common ancestor of the source and
target cluster's timelines" was printed.
