### PR TITLE
Hint bit updates screw up pg_rewind

### DIFF
--- a/README
+++ b/README
@@ -57,11 +57,11 @@ Theory of operation
 The basic idea is to copy everything from the new cluster to the old cluster,
 except for the blocks that we know to be the same.
 
-1. Scan the WAL log of the old cluster, starting from the point where the new
-cluster's timeline history forked off from the old cluster. For each WAL
-record, make a note of the data blocks that were touched. This yields a list of
-all the data blocks that were changed in the old cluster, after the new cluster
-forked off.
+1. Scan the WAL log of the old cluster, starting from the last checkpoint before
+the point where the new cluster's timeline history forked off from the old cluster.
+For each WAL record, make a note of the data blocks that were touched. This yields
+a list of all the data blocks that were changed in the old cluster, after the new
+cluster forked off.
 
 2. Copy all those changed blocks from the new cluster to the old cluster.
 

--- a/pg_rewind.c
+++ b/pg_rewind.c
@@ -245,10 +245,11 @@ main(int argc, char **argv)
 	traverse_datadir(datadir_target, &process_local_file);
 
 	/*
-	 * Read the target WAL, extracting all the pages that were modified on the
-	 * target cluster after the fork.
+	 * Read the target WAL from last checkpoint before the point of fork,
+	 * to extract all the pages that were modified on the target cluster
+	 * after the fork.
 	 */
-	extractPageMap(datadir_target, divergerec, lastcommontli);
+	extractPageMap(datadir_target, chkptrec, lastcommontli);
 
 	/* XXX: this is probably too verbose even in verbose mode */
 	if (verbose)


### PR DESCRIPTION
even when checksum feature is enabled, as only first update after checkpoint is WAL logged. Rewinding from last checkpoint before the point of fork will overwrite those updates.

Refer issue:
https://github.com/vmware/pg_rewind/issues/3
