### PR TITLE
Fix compilation for 9.4 binaries

### DIFF
--- a/parsexlog.c
+++ b/parsexlog.c
@@ -562,8 +562,6 @@ extractPageInfo(XLogRecord *record)
 
 						pageinfo_add(MAIN_FORKNUM, data->node, data->lblkno);
 						pageinfo_add(MAIN_FORKNUM, data->node, data->rblkno);
-						if (data->isRootSplit)
-							pageinfo_add(MAIN_FORKNUM, data->node, data->rootBlkno);
 						break;
 					}
 				case XLOG_GIN_VACUUM_PAGE:


### PR DESCRIPTION
Compilation of pg_rewind with 9.4 binaries failed because of an
incompatibility since gin split code has been changed.
