### PR TITLE
Make mandatory the use of data checksums

### DIFF
--- a/README
+++ b/README
@@ -84,6 +84,12 @@ failover. (pg_rewind doesn't actually apply the WAL, it just creates a backup
 label file indicating that when PostgreSQL is started, it will start replay
 from that checkpoint and apply all the required WAL)
 
+Restrictions
+------------
+
+pg_rewind needs that cluster uses data checksums to prevent data corruption that
+might occur because of hint bits.
+
 TODO
 ----
 

--- a/pg_rewind.c
+++ b/pg_rewind.c
@@ -18,6 +18,7 @@
 #include "access/xlog_internal.h"
 #include "catalog/catversion.h"
 #include "catalog/pg_control.h"
+#include "storage/bufpage.h"
 
 #include "getopt_long.h"
 
@@ -282,6 +283,16 @@ sanityChecks(void)
 		ControlFile_source.catalog_version_no != CATALOG_VERSION_NO)
 	{
 		fprintf(stderr, "clusters are not compatible with this version of pg_rewind\n");
+		exit(1);
+	}
+
+	/*
+	 * Target cluster need to use checksums, this to prevent from data
+	 * corruption that could occur because of hint bits.
+	 */
+	if (ControlFile_target.data_checksum_version != PG_DATA_CHECKSUM_VERSION)
+	{
+		fprintf(stderr, "target master need to use data checksums.\n");
 		exit(1);
 	}
 

--- a/test.sh
+++ b/test.sh
@@ -70,9 +70,9 @@ PG_VERSION_NUM=90401
 PORT_MASTER=`expr $PG_VERSION_NUM % 16384 + 49152`
 PORT_STANDBY=`expr $PORT_MASTER + 1`
 
-# Initialize master
+# Initialize master, data checksums are mandatory
 rm -rf $TEST_MASTER
-initdb -D $TEST_MASTER
+initdb -D $TEST_MASTER --data-checksums
 
 # Custom parameters for master's postgresql.conf
 cat >> $TEST_MASTER/postgresql.conf <<EOF


### PR DESCRIPTION
A sanity check based on the target's control file data is done with
its data checksum algorithm. This is to prevent data corruption that
could occur because of hint bits.
