### PR TITLE
Remove temporary directories

### DIFF
--- a/copy_fetch.c
+++ b/copy_fetch.c
@@ -299,7 +299,7 @@ copy_executeFileMap(filemap_t *map)
 				break;
 
 			case FILE_ACTION_REMOVE:
-				remove_target_file(entry->path);
+				remove_target_file(entry->path, entry->isdir);
 				break;
 
 			case FILE_ACTION_TRUNCATE:
@@ -321,7 +321,7 @@ copy_executeFileMap(filemap_t *map)
 }
 
 void
-remove_target_file(const char *path)
+remove_target_file(const char *path, bool isdir)
 {
 	char		dstpath[MAXPGPATH];
 
@@ -329,7 +329,13 @@ remove_target_file(const char *path)
 		return;
 
 	snprintf(dstpath, sizeof(dstpath), "%s/%s", datadir_target, path);
-	if (unlink(dstpath) != 0)
+	if (isdir && rmdir(dstpath) != 0)
+	{
+		fprintf(stderr, "could not remove directory \"%s\": %s\n",
+				dstpath, strerror(errno));
+		exit(1);
+	}
+	else if (!isdir && unlink(dstpath) != 0)
 	{
 		fprintf(stderr, "could not remove file \"%s\": %s\n",
 				dstpath, strerror(errno));

--- a/fetch.h
+++ b/fetch.h
@@ -47,7 +47,7 @@ extern char *slurpFile(const char *datadir, const char *path, size_t *filesize);
 typedef void (*process_file_callback_t) (const char *path, size_t size, bool isdir);
 extern void traverse_datadir(const char *datadir, process_file_callback_t callback);
 
-extern void remove_target_file(const char *path);
+extern void remove_target_file(const char *path, bool isdir);
 extern void truncate_target_file(const char *path, off_t newsize);
 extern void create_target_dir(const char *path);
 extern void check_samefile(int fd1, int fd2);

--- a/libpq_fetch.c
+++ b/libpq_fetch.c
@@ -325,7 +325,7 @@ libpq_executeFileMap(filemap_t *map)
 				break;
 
 			case FILE_ACTION_REMOVE:
-				remove_target_file(entry->path);
+				remove_target_file(entry->path, entry->isdir);
 				break;
 
 			case FILE_ACTION_TRUNCATE:


### PR DESCRIPTION
Remove temporary directories which gets created when there is
more data that can fit in memory. After operation finishes they
are no longer required.
For example: for operations such as sorting

Error message shows pg_rewind fails where any such directory is present in cluster:
.
.
.

pg_xlog/00000001000000000000001F (REMOVE)
pg_log/postgresql-2014-01-10_145742.log (REMOVE)
pg_stat/db_0.stat (REMOVE)
pg_stat/global.stat (REMOVE)
pg_stat/db_12907.stat (REMOVE)
base/pgsql_tmp (REMOVE)
could not remove file "/home/samrat/pg_rewind/data-patched-sync/base/pgsql_tmp": Is a directory
