### PR TITLE
fetchchunks table takes garbage entries because of wrong actions on files.

### DIFF
--- a/filemap.c
+++ b/filemap.c
@@ -144,12 +144,12 @@ process_remote_file(const char *path, size_t newsize, bool isdir)
 		/*
 		 * It's a data file that exists in both.
 		 *
-		 * If it's smaller in target, we can truncate it. There will also be
+		 * If it's larger in target, we can truncate it. There will also be
 		 * a WAL record of the truncation in the source system, so WAL replay
 		 * would eventually truncate the target too, but we might as well do
 		 * it now.
 		 *
-		 * If it's larger in the target, it means that it has been truncated
+		 * If it's smaller in the target, it means that it has been truncated
 		 * in the target, or enlarged in the source, or both. If it was
 		 * truncated locally, we need to copy the missing tail from the remote
 		 * system. If it was enlarged in the remote system, there will be WAL


### PR DESCRIPTION
I think there are some incorrect actions in process_remote_file function because of which fetchchunks table takes garbage entries and pg_rewind fails.

Please correct me if I am thinking it in wrong way.  

Steps to reproduce a problem which shows garbage entries in fetchchunks table:

Implement Streaming Replication (On two different machines)
create table [ create table test( id int); ]
Insert data [ insert into test (select \* from generate_series(1,100000)); ]
promote standby
on old master update all the tuples in test tables[ update test set id =888 ; ] 6 .stop old master
run pg_rewind
It will show following messages:
.
.
.
pg_stat/db_0.stat (REMOVE)
pg_stat/global.stat (REMOVE)
pg_stat/db_12907.stat (REMOVE)
unexpected result while sending file list: ERROR: value "2148249920" is out of range for type integer
CONTEXT: COPY fetchchunks, line 2728, column begin: "2148249920"

The range for integer exceeds because fetchchunk table takes garbage entries.
