### PR TITLE
Symbolic link handling and tablespace support

### DIFF
--- a/fetch.h
+++ b/fetch.h
@@ -44,13 +44,15 @@ extern void close_target_file(void);
 
 extern char *slurpFile(const char *datadir, const char *path, size_t *filesize);
 
-typedef void (*process_file_callback_t) (const char *path, size_t size, bool isdir);
+typedef void (*process_file_callback_t) (const char *path, size_t size, bool isdir, const char *tblspc_location);
 extern void traverse_datadir(const char *datadir, process_file_callback_t callback);
 
 extern void remove_target_file(const char *path);
 extern void truncate_target_file(const char *path, off_t newsize);
 extern void create_target_dir(const char *path);
 extern void remove_target_dir(const char *path);
+extern void create_target_symlink(const char *path, const char *link);
+extern void remove_target_symlink(const char *path);
 extern void check_samefile(int fd1, int fd2);
 
 

--- a/filemap.h
+++ b/filemap.h
@@ -21,6 +21,7 @@
  */
 typedef enum
 {
+	FILE_ACTION_CREATESYMLINK,      /* create local symbolic link */
 	FILE_ACTION_CREATEDIR,	/* create local dir */
 	FILE_ACTION_COPY,		/* copy whole file, overwriting if exists */
 	FILE_ACTION_COPY_TAIL,	/* copy tail from 'oldsize' to 'newsize' */
@@ -28,12 +29,15 @@ typedef enum
 							 * based on the parsed WAL) */
 	FILE_ACTION_TRUNCATE,	/* truncate local file to 'newsize' bytes */
 	FILE_ACTION_REMOVE,		/* remove local file */
-	FILE_ACTION_REMOVEDIR	/* remove local dir */
+	FILE_ACTION_REMOVEDIR,	/* remove local dir */
+	FILE_ACTION_REMOVESYMLINK       /* remove local symbolic link */
+
 } file_action_t;
 
 struct file_entry_t
 {
 	char	   *path;
+	char		*tblspc_location;
 	bool		isdir;
 
 	file_action_t action;
@@ -78,8 +82,8 @@ extern filemap_t *filemap_create(void);
 extern void print_filemap(void);
 
 /* Functions for populating the filemap */
-extern void process_remote_file(const char *path, size_t newsize, bool isdir);
-extern void process_local_file(const char *path, size_t newsize, bool isdir);
+extern void process_remote_file(const char *path, size_t newsize, bool isdir, const char *tblspc_location);
+extern void process_local_file(const char *path, size_t newsize, bool isdir, const char *tblspc_location);
 extern void process_block_change(ForkNumber forknum, RelFileNode rnode, BlockNumber blkno);
 extern void filemap_finalize(void);
 


### PR DESCRIPTION
Continuing from : https://github.com/vmware/pg_rewind/pull/22

This patch creates dedicated path for symbolic links by differentiating them from files and directories
On the top of this patch for supporting tablespace is implemented.
