### PR TITLE
Regression test failure for REL_9_3_stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 else
-subdir = contrib/pg_rewind
+subdir = contrib/pg_rewind-REL9_3_STABLE
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk


### PR DESCRIPTION
If we download REL9_3_STABLE in zip form then, regression tests will fail due to mismatch in directory name.
