### PR TITLE
Remove non empty directories

### DIFF
--- a/fetch.h
+++ b/fetch.h
@@ -51,6 +51,7 @@ extern void remove_target_file(const char *path);
 extern void truncate_target_file(const char *path, off_t newsize);
 extern void create_target_dir(const char *path);
 extern void remove_target_dir(const char *path);
+extern int remove_dir(const char *path);
 extern void check_samefile(int fd1, int fd2);
 
 


### PR DESCRIPTION
Removing non empty directories becomes necessary
while rewinding certain database operations
such as drop database, remove symbolic link
With patch pg_rewind should work for drop database operation

This is related to 
1: https://github.com/vmware/pg_rewind/issues/33
2: https://github.com/vmware/pg_rewind/issues/34

Also I have already added code for this in the tablespace patch (see remove_directory function in https://github.com/Samrat-Revagade/pg_rewind/commit/1d6b4bb6bbaa1330da57690d45d524e3691c55f9)
